### PR TITLE
Fix resize listener cleanup

### DIFF
--- a/src/app/components/three-scene/three-scene.component.ts
+++ b/src/app/components/three-scene/three-scene.component.ts
@@ -48,13 +48,14 @@ export class ThreeSceneComponent implements AfterViewInit, OnDestroy {
   //#endregion
 
   //#region LookAt Animation Variables
-  private initialLookAt = new THREE.Vector3(0, 0, 0); 
-  private targetLookAt = new THREE.Vector3(-0.063, 0.384, 0); 
-  private currentLookAt = new THREE.Vector3(0, 0, 0); 
+  private initialLookAt = new THREE.Vector3(0, 0, 0);
+  private targetLookAt = new THREE.Vector3(-0.063, 0.384, 0);
+  private currentLookAt = new THREE.Vector3(0, 0, 0);
   //#endregion
 
   //#region Screen Activation Control
   isScreenActive = false;
+  private resizeHandler = this.onWindowResize.bind(this);
   //#endregion
 
   //#region Constructor
@@ -163,7 +164,7 @@ export class ThreeSceneComponent implements AfterViewInit, OnDestroy {
 
   private setupEventListeners(): void {
     if (typeof window !== 'undefined') {
-      window.addEventListener('resize', this.onWindowResize.bind(this));
+      window.addEventListener('resize', this.resizeHandler);
     }
   }
   //#endregion
@@ -588,7 +589,7 @@ export class ThreeSceneComponent implements AfterViewInit, OnDestroy {
   }
 
   private cleanupEventListeners(): void {
-    window.removeEventListener('resize', this.onWindowResize.bind(this));
+    window.removeEventListener('resize', this.resizeHandler);
   }
   //#endregion
 }


### PR DESCRIPTION
## Summary
- store bound resize listener in ThreeSceneComponent
- use the stored handler when adding and removing the event listener

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c22f7c5988323a178420e27b61c69