### PR TITLE
Add detailed project listing

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -9,3 +9,27 @@ This directory contains a simple Express server that exposes REST endpoints for 
 3. Run `npm run dev` to start the server with nodemon.
 
 The API will be available on `http://localhost:3000` by default.
+
+### Endpoints
+
+- `GET /api/projetos` – Returns the list of projects with their stacks and
+  categories. Each project object has the following structure:
+
+```json
+{
+  "id": 1,
+  "titulo": "Meu projeto",
+  "sumario": "Breve resumo",
+  "descricao": "Descrição completa",
+  "url_repositorio": "https://github.com/usuario/repositorio",
+  "imagem_capa": "caminho/para/imagem.png",
+  "data_inicio": "2024-01-01",
+  "data_fim": "2024-02-01",
+  "stacks": [
+    { "id": 1, "nome": "Node.js", "tipo": "linguagem", "logo_url": "..." }
+  ],
+  "categorias": [
+    { "id": 1, "nome": "Web", "descricao": "Projetos web" }
+  ]
+}
+```

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -13,7 +13,43 @@ const pool = new Pool({
 
 app.get('/api/projetos', async (req, res) => {
   try {
-    const { rows } = await pool.query('SELECT * FROM projetos ORDER BY id');
+    const query = `
+      SELECT
+        p.id,
+        p.titulo,
+        p.sumario,
+        p.descricao,
+        p.url_repositorio,
+        p.imagem_capa,
+        p.data_inicio,
+        p.data_fim,
+        COALESCE(
+          json_agg(DISTINCT jsonb_build_object(
+            'id', s.id,
+            'nome', s.nome,
+            'tipo', s.tipo,
+            'logo_url', s.logo_url
+          )) FILTER (WHERE s.id IS NOT NULL),
+          '[]'
+        ) AS stacks,
+        COALESCE(
+          json_agg(DISTINCT jsonb_build_object(
+            'id', c.id,
+            'nome', c.nome,
+            'descricao', c.descricao
+          )) FILTER (WHERE c.id IS NOT NULL),
+          '[]'
+        ) AS categorias
+      FROM projetos p
+      LEFT JOIN projeto_stack ps ON ps.projeto_id = p.id
+      LEFT JOIN stacks s ON ps.stack_id = s.id
+      LEFT JOIN projeto_categoria pc ON pc.projeto_id = p.id
+      LEFT JOIN categorias c ON pc.categoria_id = c.id
+      GROUP BY p.id
+      ORDER BY p.id;
+    `;
+
+    const { rows } = await pool.query(query);
     res.json(rows);
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- enhance `/api/projetos` to return stacks and categories for each project
- document new endpoint and object structure in backend README

## Testing
- `npm start` *(fails: Unknown env config "http-proxy" but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_6856e4145e648323988fa64c293ea334