### PR TITLE
Implement project detail screen and theme support

### DIFF
--- a/frontend/src/app/components/project-detail/project-detail.component.html
+++ b/frontend/src/app/components/project-detail/project-detail.component.html
@@ -1,0 +1,13 @@
+<div class="detail-container" *ngIf="project">
+  <button class="back-btn" (click)="goBack()">Voltar</button>
+  <h2>{{ project.titulo }}</h2>
+  <img *ngIf="project.imagem_capa" [src]="project.imagem_capa" alt="Imagem" />
+  <p class="sumario">{{ project.sumario }}</p>
+  <div class="tech-list">
+    <span *ngFor="let stack of project.stacks">{{ stack.nome }}</span>
+  </div>
+  <div class="cat-list">
+    <span *ngFor="let cat of project.categorias">{{ cat.nome }}</span>
+  </div>
+  <p class="descricao">{{ project.descricao }}</p>
+</div>

--- a/frontend/src/app/components/project-detail/project-detail.component.scss
+++ b/frontend/src/app/components/project-detail/project-detail.component.scss
@@ -1,0 +1,39 @@
+:host {
+  display: block;
+  --accent-color: #0f0;
+  --accent-rgb: 0, 255, 0;
+  --text-color: #0f0;
+}
+
+:host-context(.projects) {
+  --accent-color: #000;
+  --accent-rgb: 255, 255, 255;
+  --text-color: #000;
+}
+
+.detail-container {
+  padding: 20px;
+  color: var(--text-color);
+
+  h2 {
+    margin-top: 0;
+  }
+
+  img {
+    max-width: 100%;
+    margin-bottom: 15px;
+  }
+
+  .tech-list span,
+  .cat-list span {
+    border: 1px solid var(--accent-color);
+    padding: 4px 8px;
+    margin-right: 6px;
+    margin-bottom: 6px;
+    display: inline-block;
+  }
+
+  .back-btn {
+    margin-bottom: 15px;
+  }
+}

--- a/frontend/src/app/components/project-detail/project-detail.component.ts
+++ b/frontend/src/app/components/project-detail/project-detail.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NavigationProvider } from '../../providers/navigation.provider';
+import { Projeto } from '../../services/project.service';
+
+@Component({
+  selector: 'app-project-detail',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './project-detail.component.html',
+  styleUrl: './project-detail.component.scss'
+})
+export class ProjectDetailComponent implements OnInit {
+  project!: Projeto;
+
+  constructor(private navigation: NavigationProvider) {}
+
+  ngOnInit() {
+    const state = this.navigation.getCurrentState();
+    this.project = state.data?.project;
+  }
+
+  goBack() {
+    this.navigation.navigate('/projects');
+  }
+}

--- a/frontend/src/app/components/projects/projects.component.html
+++ b/frontend/src/app/components/projects/projects.component.html
@@ -35,7 +35,16 @@
           <h3>{{ project.titulo }}</h3>
           <p>{{ project.sumario }}</p>
           <div class="project-tech">
-            <span class="tech-tag" *ngFor="let stack of project.stacks">{{ stack.nome }}</span>
+            <ng-container *ngFor="let stack of project.stacks | slice:0:4; let i = index">
+              <span class="tech-tag">{{ stack.nome }}</span>
+              <span class="tech-tag" *ngIf="i === 3 && project.stacks.length > 4">...</span>
+            </ng-container>
+          </div>
+          <div class="project-categories">
+            <ng-container *ngFor="let cat of project.categorias | slice:0:3; let i = index">
+              <span class="cat-tag">{{ cat.nome }}</span>
+              <span class="cat-tag" *ngIf="i === 2 && project.categorias.length > 3">...</span>
+            </ng-container>
           </div>
           <div class="project-links">
             <a href="#" class="project-link" (click)="onProjectClick(project.titulo); $event.preventDefault()">Ver

--- a/frontend/src/app/components/projects/projects.component.scss
+++ b/frontend/src/app/components/projects/projects.component.scss
@@ -4,17 +4,29 @@
   flex-direction: column;
 }
 
+:host {
+  --accent-color: #0f0;
+  --accent-rgb: 0, 255, 0;
+  --text-color: #0f0;
+}
+
+:host-context(.projects) {
+  --accent-color: #000;
+  --accent-rgb: 255, 255, 255;
+  --text-color: #000;
+}
+
 // Header
 .projects-header {
   text-align: center;
   margin-bottom: 40px;
-  border-bottom: 2px solid #0f0;
+  border-bottom: 2px solid var(--accent-color);
   padding-bottom: 20px;
   
   h1 {
     font-size: 3em;
     margin: 0;
-    text-shadow: 0 0 20px #0f0;
+    text-shadow: 0 0 20px var(--accent-color);
     letter-spacing: 4px;
     animation: headerGlow 3s ease-in-out infinite alternate;
   }
@@ -23,7 +35,7 @@
     font-size: 1.2em;
     margin: 10px 0 0 0;
     opacity: 0.8;
-    text-shadow: 0 0 10px #0f0;
+    text-shadow: 0 0 10px var(--accent-color);
   }
 }
 
@@ -37,8 +49,8 @@
   
   .nav-btn {
     background: transparent;
-    border: 2px solid #0f0;
-    color: #0f0;
+    border: 2px solid var(--accent-color);
+    color: var(--accent-color);
     padding: 12px 24px;
     font-family: 'Courier New', monospace;
     font-size: 0.9em;
@@ -48,15 +60,15 @@
     letter-spacing: 1px;
     
     &:hover {
-      background: #0f0;
+      background: var(--accent-color);
       color: #000;
-      box-shadow: 0 0 20px #0f0;
+      box-shadow: 0 0 20px var(--accent-color);
     }
     
     &.active {
-      background: #0f0;
+      background: var(--accent-color);
       color: #000;
-      box-shadow: 0 0 15px #0f0;
+      box-shadow: 0 0 15px var(--accent-color);
     }
   }
 }
@@ -75,8 +87,8 @@
     font-size: 2em;
     margin-bottom: 30px;
     text-align: center;
-    text-shadow: 0 0 15px #0f0;
-    border-bottom: 1px solid rgba(0, 255, 0, 0.3);
+    text-shadow: 0 0 15px var(--accent-color);
+    border-bottom: 1px solid rgba(var(--accent-rgb), 0.3);
     padding-bottom: 15px;
   }
   
@@ -87,15 +99,15 @@
 }
 
 .project-card {
-  background: rgba(0, 255, 0, 0.05);
-  border: 2px solid rgba(0, 255, 0, 0.3);
+  background: rgba(var(--accent-rgb), 0.05);
+  border: 2px solid rgba(var(--accent-rgb), 0.3);
   border-radius: 10px;
   padding: 20px;
   transition: all 0.3s ease;
   
   &:hover {
-    border-color: #0f0;
-    box-shadow: 0 0 25px rgba(0, 255, 0, 0.3);
+    border-color: var(--accent-color);
+    box-shadow: 0 0 25px rgba(var(--accent-rgb), 0.3);
     transform: translateY(-5px);
   }
   
@@ -111,14 +123,14 @@
     }
     
     .placeholder {
-      background: rgba(0, 255, 0, 0.1);
-      border: 1px dashed #0f0;
+      background: rgba(var(--accent-rgb), 0.1);
+      border: 1px dashed var(--accent-color);
       height: 200px;
       display: flex;
       align-items: center;
       justify-content: center;
       font-size: 1.2em;
-      text-shadow: 0 0 10px #0f0;
+      text-shadow: 0 0 10px var(--accent-color);
       border-radius: 5px;
     }
   }
@@ -127,7 +139,7 @@
     h3 {
       font-size: 1.4em;
       margin: 0 0 10px 0;
-      text-shadow: 0 0 10px #0f0;
+      text-shadow: 0 0 10px var(--accent-color);
     }
     
     p {
@@ -144,12 +156,27 @@
     flex-wrap: wrap;
     
     .tech-tag {
-      background: rgba(0, 255, 0, 0.2);
-      border: 1px solid #0f0;
+      background: rgba(var(--accent-rgb), 0.2);
+      border: 1px solid var(--accent-color);
       padding: 4px 8px;
       font-size: 0.8em;
       border-radius: 3px;
-      text-shadow: 0 0 5px #0f0;
+      text-shadow: 0 0 5px var(--accent-color);
+    }
+  }
+
+  .project-categories {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+
+    .cat-tag {
+      background: rgba(var(--accent-rgb), 0.1);
+      border: 1px solid var(--accent-color);
+      padding: 2px 6px;
+      font-size: 0.75em;
+      border-radius: 3px;
     }
   }
   
@@ -158,18 +185,18 @@
     gap: 15px;
     
     .project-link {
-      color: #0f0;
+      color: var(--accent-color);
       text-decoration: none;
-      border: 1px solid #0f0;
+      border: 1px solid var(--accent-color);
       padding: 8px 16px;
       border-radius: 3px;
       transition: all 0.3s ease;
       font-size: 0.9em;
       
       &:hover {
-        background: #0f0;
+        background: var(--accent-color);
         color: #000;
-        box-shadow: 0 0 15px #0f0;
+        box-shadow: 0 0 15px var(--accent-color);
       }
     }
   }
@@ -181,8 +208,8 @@
     font-size: 2em;
     margin-bottom: 30px;
     text-align: center;
-    text-shadow: 0 0 15px #0f0;
-    border-bottom: 1px solid rgba(0, 255, 0, 0.3);
+    text-shadow: 0 0 15px var(--accent-color);
+    border-bottom: 1px solid rgba(var(--accent-rgb), 0.3);
     padding-bottom: 15px;
   }
   
@@ -192,8 +219,8 @@
     gap: 20px;
     
     .skill-item {
-      background: rgba(0, 255, 0, 0.1);
-      border: 2px solid rgba(0, 255, 0, 0.3);
+      background: rgba(var(--accent-rgb), 0.1);
+      border: 2px solid rgba(var(--accent-rgb), 0.3);
       padding: 30px 20px;
       text-align: center;
       border-radius: 8px;
@@ -202,9 +229,9 @@
       cursor: pointer;
       
       &:hover {
-        border-color: #0f0;
-        box-shadow: 0 0 20px rgba(0, 255, 0, 0.3);
-        background: rgba(0, 255, 0, 0.15);
+        border-color: var(--accent-color);
+        box-shadow: 0 0 20px rgba(var(--accent-rgb), 0.3);
+        background: rgba(var(--accent-rgb), 0.15);
       }
     }
   }
@@ -215,7 +242,7 @@
   text-align: center;
   margin-top: 40px;
   padding-top: 20px;
-  border-top: 1px solid rgba(0, 255, 0, 0.3);
+  border-top: 1px solid rgba(var(--accent-rgb), 0.3);
   
   p {
     margin: 0;
@@ -227,8 +254,8 @@
 
 // Animations
 @keyframes headerGlow {
-  0% { text-shadow: 0 0 20px #0f0; }
-  100% { text-shadow: 0 0 30px #0f0, 0 0 40px #0f0; }
+  0% { text-shadow: 0 0 20px var(--accent-color); }
+  100% { text-shadow: 0 0 30px var(--accent-color), 0 0 40px var(--accent-color); }
 }
 
 @keyframes blink {

--- a/frontend/src/app/components/projects/projects.component.ts
+++ b/frontend/src/app/components/projects/projects.component.ts
@@ -56,8 +56,10 @@ export class ProjectsComponent implements OnInit, OnDestroy {
   }
 
   onProjectClick(projectName: string) {
-    console.log(`🚀 Abrindo projeto: ${projectName}`);
-    // Implementar abertura de projeto aqui
+    const project = this.projects.find(p => p.titulo === projectName);
+    if (project) {
+      this.navigationProvider.navigate('/project-detail', { project });
+    }
   }
 
   onGitHubClick(projectName: string) {

--- a/frontend/src/app/components/screen/screen.component.html
+++ b/frontend/src/app/components/screen/screen.component.html
@@ -1,4 +1,4 @@
-<div class="screen-overlay" [class.active]="isActive">
+<div class="screen-overlay" [class.active]="isActive" [ngClass]="currentTheme">
   <div class="screen-content">
     <!-- Renderização dinâmica do componente baseado na rota atual -->
     <ng-container *ngComponentOutlet="currentComponent"></ng-container>

--- a/frontend/src/app/components/screen/screen.component.scss
+++ b/frontend/src/app/components/screen/screen.component.scss
@@ -116,6 +116,53 @@
     }
 }
 
+.screen-overlay.projects {
+    background: linear-gradient(
+        145deg,
+        rgba(255, 255, 255, 0.08) 0%,
+        rgba(255, 255, 255, 0.03) 30%,
+        rgba(255, 255, 255, 0.06) 70%,
+        rgba(255, 255, 255, 0.08) 100%
+    );
+    animation: screenGlowWhite 4s ease-in-out infinite alternate;
+
+    .screen-content {
+        color: #000;
+        text-shadow: none;
+    }
+
+    &::before {
+        background:
+            repeating-linear-gradient(
+                0deg,
+                transparent,
+                transparent 2px,
+                rgba(0, 0, 0, 0.03) 2px,
+                rgba(0, 0, 0, 0.03) 4px
+            ),
+            radial-gradient(
+                ellipse at center,
+                transparent 50%,
+                rgba(0, 0, 0, 0.4) 100%
+            );
+    }
+}
+
+@keyframes screenGlowWhite {
+    0% {
+        box-shadow:
+            inset 0 0 60px rgba(255, 255, 255, 0.12),
+            0 0 30px rgba(255, 255, 255, 0.2),
+            inset 0 0 0 2px rgba(255, 255, 255, 0.15);
+    }
+    100% {
+        box-shadow:
+            inset 0 0 80px rgba(255, 255, 255, 0.18),
+            0 0 50px rgba(255, 255, 255, 0.3),
+            inset 0 0 0 2px rgba(255, 255, 255, 0.2);
+    }
+}
+
 // Animações do container CRT
 @keyframes screenGlow {
     0% { 

--- a/frontend/src/app/components/screen/screen.component.ts
+++ b/frontend/src/app/components/screen/screen.component.ts
@@ -16,6 +16,9 @@ export class ScreenComponent implements OnInit, OnDestroy {
   // Componente atual a ser renderizado
   currentComponent: Type<any> | null = null;
 
+  // Tema visual atual
+  currentTheme: string = 'bios';
+
   // Subject para cleanup de subscriptions
   private destroy$ = new Subject<void>();
 
@@ -51,6 +54,7 @@ export class ScreenComponent implements OnInit, OnDestroy {
    */
   private updateCurrentComponent(state: NavigationState) {
     this.currentComponent = state.component;
+    this.currentTheme = state.theme || 'bios';
     console.log(`📺 Renderizando componente: ${state.screenName} (${state.route})`);
     
     // Se houver dados, pode ser útil para componentes filhos

--- a/frontend/src/app/config/routes.config.ts
+++ b/frontend/src/app/config/routes.config.ts
@@ -4,6 +4,7 @@ import { Type } from '@angular/core';
 // Imports dos componentes
 import { BiosScreenComponent } from '../components/bios-screen/bios-screen.component';
 import { ProjectsComponent } from '../components/projects/projects.component';
+import { ProjectDetailComponent } from '../components/project-detail/project-detail.component';
 
 /**
  * Configuração central de todas as rotas da aplicação
@@ -13,12 +14,20 @@ export const APP_ROUTES: RouteConfig[] = [
   {
     route: '/bios',
     component: BiosScreenComponent,
-    name: 'bios'
+    name: 'bios',
+    theme: 'bios'
   },
   {
     route: '/projects',
     component: ProjectsComponent,
-    name: 'projects'
+    name: 'projects',
+    theme: 'projects'
+  },
+  {
+    route: '/project-detail',
+    component: ProjectDetailComponent,
+    name: 'project-detail',
+    theme: 'projects'
   }
 ];
 

--- a/frontend/src/app/providers/navigation.provider.ts
+++ b/frontend/src/app/providers/navigation.provider.ts
@@ -7,12 +7,14 @@ export interface NavigationState {
   route: string;
   data: any;
   component: Type<any>;
+  theme?: string;
 }
 
 export interface RouteConfig {
   route: string;
   component: Type<any>;
   name: string;
+  theme?: string;
 }
 
 @Injectable({
@@ -25,7 +27,8 @@ export class NavigationProvider {
     screenName: 'bios',
     route: '/bios',
     data: {},
-    component: null as any // Será definido após registro das rotas
+    component: null as any, // Será definido após registro das rotas
+    theme: 'bios'
   });
 
   public currentState$: Observable<NavigationState> = this.navigationState.asObservable();
@@ -45,7 +48,8 @@ export class NavigationProvider {
     if (routeConfig.route === '/bios' && !this.navigationState.value.component) {
       this.updateNavigationState({
         ...this.navigationState.value,
-        component: routeConfig.component
+        component: routeConfig.component,
+        theme: routeConfig.theme
       });
     }
   }
@@ -72,7 +76,8 @@ export class NavigationProvider {
       screenName: routeConfig.name,
       route: route,
       data: data,
-      component: routeConfig.component
+      component: routeConfig.component,
+      theme: routeConfig.theme
     };
 
     this.updateNavigationState(newState);


### PR DESCRIPTION
## Summary
- add route theming support in navigation provider
- implement projects screen theme and project detail view
- allow navigation to project detail
- tweak CRT screen colors based on theme
- limit displayed stacks and categories

## Testing
- `npm test --silent` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857224f38288323824e3cfc9d435865